### PR TITLE
chore: make "cypressWebpackConfigPath" configurable from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ If you want to exclude files from coverage, for example `src/serviceWorker.js`, 
 }
 ```
 
+## Instrument a fork
+
+To instrument a [fork of `react-scripts`](https://create-react-app.dev/docs/alternatives-to-ejecting/), provide the path to the new `webpack.config.js` in your `package.json` as `cypressWebpackConfigPath`, e.g.:
+
+```json
+{
+  "cypressWebpackConfigPath": "./node_modules/@my-org/my-react-scripts-fork/config/webpack.config.js"
+}
+```
+
 ## Debugging
 
 Run with environment variable `DEBUG=instrument-cra` to see the verbose logs

--- a/index.js
+++ b/index.js
@@ -2,13 +2,29 @@ const debug = require('debug')('instrument-cra')
 const path = require('path')
 const findYarnWorkspaceRoot = require('find-yarn-workspace-root')
 
-const webpackConfigPath = path.resolve(
-  findYarnWorkspaceRoot() || process.cwd(),
-  'node_modules',
-  'react-scripts',
-  'config',
-  'webpack.config.js'
-)
+const workspaceRoot = findYarnWorkspaceRoot() || process.cwd()
+const packagePath = path.resolve(workspaceRoot, 'package.json')
+
+let package = { cypressWebpackConfigPath: undefined }
+try {
+  package = require(packagePath)
+} catch {
+  debug('failed to read package.json at path: %s', packagePath)
+}
+
+const webpackConfigPath =
+  package.cypressWebpackConfigPath !== undefined
+    ? path.resolve(
+        workspaceRoot,
+        path.normalize(package.cypressWebpackConfigPath)
+      )
+    : path.resolve(
+        workspaceRoot,
+        'node_modules',
+        'react-scripts',
+        'config',
+        'webpack.config.js'
+      )
 
 debug('path to react-scripts own webpack.config.js: %s', webpackConfigPath)
 


### PR DESCRIPTION
Fixes https://github.com/cypress-io/instrument-cra/issues/132