### PR TITLE
feat(prodbuild): Only show warning when running instrumentation using npm run build

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,7 @@ const webpackFactory = require(webpackConfigPath)
 
 function fakeConfig (envName) {
   if (envName !== 'development') {
-    throw new Error(
-      'Can overwrite cra webpack config only for development environment'
-    )
+    console.warn("WARNING - Modifying webpack outside of development environment")
   }
 
   debug('calling real CRA webpack factory with env "%s"', envName)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "cypress run",
     "start": "react-scripts -r . start",
+    "build": "react-scripts -r . build",
     "cy:open": "cypress open",
     "dev": "start-test 3000 cy:open",
     "e2e": "start-test 3000",
@@ -49,6 +50,11 @@
     "extends": "react-app"
   },
   "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",


### PR DESCRIPTION
Solves [#135](https://github.com/cypress-io/instrument-cra/issues/135)