### PR TITLE
Instrument production build via env variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ process.env.NODE_ENV = 'development'
 const webpackFactory = require(webpackConfigPath)
 
 function fakeConfig (envName) {
-  if (envName !== 'development') {
+  if (envName !== 'development' && process.env.CYPRESS_INSTRUMENT_PRODUCTION !== 'true') {
     throw new Error(
       'Can overwrite cra webpack config only for development environment'
     )


### PR DESCRIPTION
Fixes #135
(not tested)

Allow instrumentation of production build via an environment variable - CYPRESS_INSTRUMENT_PRODUCTION