### PR TITLE
fix Yarn workspace pathing for Yarn 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const debug = require('debug')('instrument-cra')
 const path = require('path')
 const findYarnWorkspaceRoot = require('find-yarn-workspace-root')
 
-const workspaceRoot = findYarnWorkspaceRoot() || process.cwd()
+const workspaceRoot = findYarnWorkspaceRoot(__dirname) || process.cwd()
 const packagePath = path.resolve(workspaceRoot, 'package.json')
 
 let cypressWebpackConfigPath


### PR DESCRIPTION
Before, scripts from the root of a Yarn monorepo would result in the `findYarnWorkspaceRoot()` returning the current working directory. Example:

```
// package.json
{
  "scripts":" {
    "start": "yarn workspace my-application run start"
  }
}
```

In the above example, running `yarn start` in the monorepo root would return the root directory for the Yarn workspace, when in reality, the workspace is `my-application` and Node modules should be imported relative to that directory.

With this change, the initial directory is `__dirname` instead of `process.cwd()`, which accurately returns `/path/to/my-application`.

This change allows the `cypressWebpackConfigPath` property of the correct workspace to be read from the correct `package.json`, where previously the `cypressWebpackConfigPath` had to be read from the root directory. The previous behavior is incorrect as each workspace should support a different `cypressWebpackConfigPath` value.

Thanks,