### PR TITLE
fix: 🐛 custom node_module path alias

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,17 +20,17 @@ debug('finding webpack config %o', {
 })
 const webpackConfigPath =
   cypressWebpackConfigPath
-    ? path.resolve(
+    ? require.resolve(path.join(
         workspaceRoot,
         path.normalize(cypressWebpackConfigPath)
-      )
-    : path.resolve(
+      ))
+    : require.resolve(path.join(
         workspaceRoot,
         'node_modules',
         'react-scripts',
         'config',
         'webpack.config.js'
-      )
+      ))
 
 debug('path to react-scripts own webpack.config.js: %s', webpackConfigPath)
 


### PR DESCRIPTION
I use docker, and ln -s custom node_modules path for cache, but give the error
```sh
/npm/node_modules/@cypress/instrument-cra/index.js:72
require.cache[webpackConfigPath].exports = fakeConfig
                                         ^
TypeError: Cannot set property 'exports' of undefined
```